### PR TITLE
Allow admins to read all profiles

### DIFF
--- a/supabase/migrations/20250930090000_enable_admin_profile_select.sql
+++ b/supabase/migrations/20250930090000_enable_admin_profile_select.sql
@@ -1,0 +1,7 @@
+-- Allow admins to read all profiles via security-definer helper
+DROP POLICY IF EXISTS "Admins can view all profiles" ON public.profiles;
+
+CREATE POLICY "Admins can view all profiles"
+ON public.profiles
+FOR SELECT
+USING (public.is_admin(auth.uid()));


### PR DESCRIPTION
## Summary
- add a new RLS policy that lets admin users select every profile via the existing `public.is_admin` helper

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d63b13fa70832f83318a7ac2d522d7