### PR TITLE
Ensure Caddy runner image includes wget for health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN npm run build
 # --- serve with Caddy (no TLS here; Cloudflare handles TLS) ---
 FROM caddy:2 AS runner
 # Caddy will listen on :8080 (see Caddyfile)
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends wget \
+  && rm -rf /var/lib/apt/lists/*
 COPY Caddyfile /etc/caddy/Caddyfile
 COPY --from=builder /app/dist /usr/share/caddy
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- install wget in the final Caddy image so the docker-compose healthcheck command is available

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e54ef725cc832fa8c080c34bdb64e0